### PR TITLE
Feat News의 전반적인 API 기능 구현

### DIFF
--- a/src/main/java/com/project/bunnyCare/config/SecurityConfig.java
+++ b/src/main/java/com/project/bunnyCare/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -41,6 +42,9 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth->auth
                         .requestMatchers("/actuator/**",authUrl,"/favicon.ico").permitAll()
+                        .requestMatchers(HttpMethod.POST,"/api/v1/news").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH,"/api/v1/news/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE,"/api/v1/news/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .build();

--- a/src/main/java/com/project/bunnyCare/news/application/NewsMapper.java
+++ b/src/main/java/com/project/bunnyCare/news/application/NewsMapper.java
@@ -1,0 +1,17 @@
+package com.project.bunnyCare.news.application;
+
+import com.project.bunnyCare.news.domain.NewsEntity;
+import com.project.bunnyCare.news.interfaces.dto.CreateNewsRequestDto;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
+public interface NewsMapper {
+
+    NewsEntity toEntity(CreateNewsRequestDto requestDto);
+}

--- a/src/main/java/com/project/bunnyCare/news/application/NewsService.java
+++ b/src/main/java/com/project/bunnyCare/news/application/NewsService.java
@@ -1,0 +1,59 @@
+package com.project.bunnyCare.news.application;
+
+import com.project.bunnyCare.common.util.AuthUtil;
+import com.project.bunnyCare.news.domain.NewsEntity;
+import com.project.bunnyCare.news.domain.NewsReader;
+import com.project.bunnyCare.news.domain.NewsStore;
+import com.project.bunnyCare.news.interfaces.dto.CreateNewsRequestDto;
+import com.project.bunnyCare.news.interfaces.dto.NewsDetailResponseDto;
+import com.project.bunnyCare.user.domain.UserEntity;
+import com.project.bunnyCare.user.domain.UserReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NewsService {
+
+    private final NewsStore newsStore;
+    private final NewsReader newsReader;
+    private final UserReader userReader;
+
+    @Transactional
+    public NewsDetailResponseDto createNews(CreateNewsRequestDto dto) {
+        Long userId = AuthUtil.getUserId();
+        UserEntity createUser = userReader.findById(userId);
+        NewsEntity newsEntity = NewsEntity.create(dto.title(), dto.content(), createUser);
+        return NewsDetailResponseDto.from(newsStore.save(newsEntity));
+    }
+
+    @Transactional
+    public NewsDetailResponseDto updateNews(CreateNewsRequestDto dto, Long newsId) {
+        NewsEntity newsEntity = newsReader.findById(newsId);
+        UserEntity updateUser = userReader.findById(AuthUtil.getUserId());
+        newsEntity.update(dto.title(), dto.content(), updateUser);
+        return NewsDetailResponseDto.from(newsEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public List<NewsDetailResponseDto> getNewsList() {
+        return newsReader.findAllByDeleteYn("N")
+                .stream().map(NewsDetailResponseDto::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public NewsDetailResponseDto getNews(Long newsId) {
+        return NewsDetailResponseDto.from(newsReader.findById(newsId));
+    }
+
+    @Transactional
+    public void deleteNews(Long newsId) {
+        NewsEntity newsEntity = newsReader.findById(newsId);
+        newsEntity.delete();
+    }
+}

--- a/src/main/java/com/project/bunnyCare/news/domain/NewsEntity.java
+++ b/src/main/java/com/project/bunnyCare/news/domain/NewsEntity.java
@@ -1,0 +1,56 @@
+package com.project.bunnyCare.news.domain;
+
+import com.project.bunnyCare.common.BaseEntity;
+import com.project.bunnyCare.user.domain.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "news")
+@Entity
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewsEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "delete_yn")
+    private String deleteYn;
+
+    @ManyToOne
+    private UserEntity createUser;
+
+    @ManyToOne
+    private UserEntity updateUser;
+
+
+    public static NewsEntity create(String title, String content, UserEntity user) {
+       return NewsEntity.builder()
+               .title(title)
+               .content(content)
+               .createUser(user)
+               .deleteYn("N")
+               .build();
+    }
+
+    public void update(String title, String content, UserEntity user) {
+        this.title = title;
+        this.content = content;
+        this.updateUser = user;
+    }
+
+    public void delete() {
+        this.deleteYn = "Y";
+    }
+
+}

--- a/src/main/java/com/project/bunnyCare/news/domain/NewsReader.java
+++ b/src/main/java/com/project/bunnyCare/news/domain/NewsReader.java
@@ -1,0 +1,8 @@
+package com.project.bunnyCare.news.domain;
+
+import java.util.List;
+
+public interface NewsReader {
+    NewsEntity findById(Long id);
+    List<NewsEntity> findAllByDeleteYn(String n);
+}

--- a/src/main/java/com/project/bunnyCare/news/domain/NewsResponseCode.java
+++ b/src/main/java/com/project/bunnyCare/news/domain/NewsResponseCode.java
@@ -1,0 +1,19 @@
+package com.project.bunnyCare.news.domain;
+
+import com.project.bunnyCare.common.api.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum NewsResponseCode implements ResponseCode {
+    CREATE(200, "created", "뉴스가 성공적으로 생성되었습니다."),
+    NOT_FOUND(404, "not found", "뉴스를 찾을 수 없습니다."),
+    UPDATE(200, "updated", "뉴스가 성공적으로 수정되었습니다."),
+    SUCCESS(200, "success", "뉴스가 성공적으로 조회되었습니다."),
+    DELETE(200, "deleted", "뉴스가 성공적으로 삭제되었습니다.");
+
+    private int code;
+    private String status;
+    private String message;
+}

--- a/src/main/java/com/project/bunnyCare/news/domain/NewsStore.java
+++ b/src/main/java/com/project/bunnyCare/news/domain/NewsStore.java
@@ -1,0 +1,8 @@
+package com.project.bunnyCare.news.domain;
+
+public interface NewsStore {
+
+    NewsEntity save(NewsEntity newsEntity);
+
+
+}

--- a/src/main/java/com/project/bunnyCare/news/infrastructure/NewsReaderImpl.java
+++ b/src/main/java/com/project/bunnyCare/news/infrastructure/NewsReaderImpl.java
@@ -1,0 +1,27 @@
+package com.project.bunnyCare.news.infrastructure;
+
+import com.project.bunnyCare.common.exception.ApiException;
+import com.project.bunnyCare.news.domain.NewsEntity;
+import com.project.bunnyCare.news.domain.NewsReader;
+import com.project.bunnyCare.news.domain.NewsResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NewsReaderImpl implements NewsReader {
+
+    private final NewsRepository newsRepository;
+
+    @Override
+    public NewsEntity findById(Long id) {
+        return newsRepository.findById(id).orElseThrow(() -> new ApiException(NewsResponseCode.NOT_FOUND));
+    }
+
+    @Override
+    public List<NewsEntity> findAllByDeleteYn(String n) {
+        return newsRepository.findAllByDeleteYn(n);
+    }
+}

--- a/src/main/java/com/project/bunnyCare/news/infrastructure/NewsRepository.java
+++ b/src/main/java/com/project/bunnyCare/news/infrastructure/NewsRepository.java
@@ -1,0 +1,11 @@
+package com.project.bunnyCare.news.infrastructure;
+
+import com.project.bunnyCare.news.domain.NewsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NewsRepository extends JpaRepository<NewsEntity, Long> {
+
+    List<NewsEntity> findAllByDeleteYn(String n);
+}

--- a/src/main/java/com/project/bunnyCare/news/infrastructure/NewsStoreImpl.java
+++ b/src/main/java/com/project/bunnyCare/news/infrastructure/NewsStoreImpl.java
@@ -1,0 +1,22 @@
+package com.project.bunnyCare.news.infrastructure;
+
+import com.project.bunnyCare.news.domain.NewsEntity;
+import com.project.bunnyCare.news.domain.NewsStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NewsStoreImpl implements NewsStore {
+
+    private final NewsRepository newsRepository;
+
+    @Override
+    public NewsEntity save(NewsEntity newsEntity) {
+        return newsRepository.save(newsEntity);
+    }
+
+
+}

--- a/src/main/java/com/project/bunnyCare/news/interfaces/NewsApiController.java
+++ b/src/main/java/com/project/bunnyCare/news/interfaces/NewsApiController.java
@@ -1,0 +1,55 @@
+package com.project.bunnyCare.news.interfaces;
+
+import com.project.bunnyCare.common.api.ApiResponse;
+import com.project.bunnyCare.news.application.NewsService;
+import com.project.bunnyCare.news.domain.NewsResponseCode;
+import com.project.bunnyCare.news.interfaces.dto.CreateNewsRequestDto;
+import com.project.bunnyCare.news.interfaces.dto.NewsDetailResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/${api.version}/news")
+@RequiredArgsConstructor
+public class NewsApiController {
+
+    private final NewsService newsService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<NewsDetailResponseDto>> createNews(
+            @RequestBody CreateNewsRequestDto requestDto
+            ) {
+        NewsDetailResponseDto response = newsService.createNews(requestDto);
+        return ResponseEntity.ok(ApiResponse.ok(NewsResponseCode.CREATE,response));
+    }
+
+    @PatchMapping("/{newsId}")
+    public ResponseEntity<ApiResponse<NewsDetailResponseDto>> updateNews(
+            @RequestBody CreateNewsRequestDto requestDto,
+            @PathVariable Long newsId
+    ) {
+        NewsDetailResponseDto response = newsService.updateNews(requestDto, newsId);
+        return ResponseEntity.ok(ApiResponse.ok(NewsResponseCode.UPDATE, response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NewsDetailResponseDto>>> getNewsList(){
+        List<NewsDetailResponseDto> response = newsService.getNewsList();
+        return ResponseEntity.ok(ApiResponse.ok(NewsResponseCode.SUCCESS, response));
+    }
+
+    @GetMapping("/{newsId}")
+    public ResponseEntity<ApiResponse<NewsDetailResponseDto>> getNews(@PathVariable Long newsId){
+        NewsDetailResponseDto response = newsService.getNews(newsId);
+        return ResponseEntity.ok(ApiResponse.ok(NewsResponseCode.SUCCESS, response));
+    }
+
+    @DeleteMapping("/{newsId}")
+    public ResponseEntity<ApiResponse<Void>> deleteNews(@PathVariable Long newsId){
+        newsService.deleteNews(newsId);
+        return ResponseEntity.ok(ApiResponse.ok(NewsResponseCode.DELETE));
+    }
+}

--- a/src/main/java/com/project/bunnyCare/news/interfaces/dto/CreateNewsRequestDto.java
+++ b/src/main/java/com/project/bunnyCare/news/interfaces/dto/CreateNewsRequestDto.java
@@ -1,0 +1,7 @@
+package com.project.bunnyCare.news.interfaces.dto;
+
+public record CreateNewsRequestDto(
+        String title,
+        String content
+) {
+}

--- a/src/main/java/com/project/bunnyCare/news/interfaces/dto/NewsDetailResponseDto.java
+++ b/src/main/java/com/project/bunnyCare/news/interfaces/dto/NewsDetailResponseDto.java
@@ -1,0 +1,24 @@
+package com.project.bunnyCare.news.interfaces.dto;
+
+import com.project.bunnyCare.news.domain.NewsEntity;
+
+import java.time.LocalDateTime;
+
+public record NewsDetailResponseDto(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        String createdBy
+) {
+
+    public static NewsDetailResponseDto from(NewsEntity entity) {
+        return new NewsDetailResponseDto(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getCreateUser().getName()
+        );
+    }
+}


### PR DESCRIPTION
## API 기능 구현
</br>
`POST` /api/v1/news : 뉴스 생성 - 어드민 권한 유저만 가능
`PATCH` /api/v1/news/{newsId} : 뉴스 수정 - 어드민 권한 유저만 가능
`DELETE` /api/v1/news/{newsId} : 뉴스 삭제 - 어드민 권한 유저만 가능
`GET` /api/v1/news : 뉴스 리스트 조회
`GET` /api/v1/news/{newsId} : 뉴스 단건 조회